### PR TITLE
Replace str ascii method with py36 compliant function

### DIFF
--- a/synergy_file_reader/tools.py
+++ b/synergy_file_reader/tools.py
@@ -20,10 +20,18 @@ def row_iter(exhaust_warning=True):
 
 VALID_ROWS = set(row_iter(exhaust_warning=False))
 
+def isascii(s):
+    try:
+        s.encode('ascii')
+    except UnicodeEncodeError:
+        return False
+    else:
+        return True
+
 def split_alpha_and_number(name):
 	if name=="":
 		raise ValueError("Empty name.")
-	elif not name.isascii():
+	elif not isascii(name):
 		raise ValueError("Not an ASCII name")
 	
 	for i in range(len(name)+1):


### PR DESCRIPTION
The setup.py has py3.6+, but the str `ascii()` method was introduced in py3.7.

Adding a function to accomplish the same thing that's py3.6 compliant ([source](https://stackoverflow.com/a/32357552))

All tests passed except:
```
FAILED test_synergy_file.py::test_spectrum - FileNotFoundError: [Errno 2] No such file or directory: 'spectrum.txt'
```
I think that file was not checked it, possibly?